### PR TITLE
Add non-destructive crop viewport with two-layer handle system

### DIFF
--- a/src/canvas-image.ts
+++ b/src/canvas-image.ts
@@ -1,0 +1,204 @@
+/**
+ * CropFrame defines the visible region of an image.
+ * Coordinates are relative to the image origin.
+ */
+export type CropFrame = {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+};
+
+/**
+ * CanvasImage represents an image loaded into the editor.
+ * Stored position is in world coordinates.
+ */
+export type CanvasImage = {
+  readonly id: string;
+  readonly image: HTMLImageElement | HTMLCanvasElement;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly loaded: boolean;
+  readonly cropFrame: CropFrame;
+};
+
+let imageIdCounter = 0;
+
+export const createCanvasImage = (): CanvasImage => ({
+  id: `image-${++imageIdCounter}`,
+  image: new Image(),
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  loaded: false,
+  cropFrame: { x: 0, y: 0, width: 0, height: 0 },
+});
+
+export const loadImage = (src: string): Promise<CanvasImage> => {
+  const img = new Image();
+
+  return new Promise((resolve, reject) => {
+    img.onload = () => {
+      resolve({
+        id: `image-${++imageIdCounter}`,
+        image: img,
+        x: 0,
+        y: 0,
+        width: img.width,
+        height: img.height,
+        loaded: true,
+        cropFrame: { x: 0, y: 0, width: img.width, height: img.height },
+      });
+    };
+    img.onerror = reject;
+    img.src = src;
+  });
+};
+
+/**
+ * Clamp the crop frame to stay within image bounds
+ */
+export const clampCropFrame = (image: CanvasImage): CanvasImage => {
+  const clampedX = Math.max(0, Math.min(image.cropFrame.x, image.width));
+  const clampedY = Math.max(0, Math.min(image.cropFrame.y, image.height));
+  const clampedWidth = Math.min(image.cropFrame.width, image.width - clampedX);
+  const clampedHeight = Math.min(
+    image.cropFrame.height,
+    image.height - clampedY
+  );
+
+  return {
+    ...image,
+    cropFrame: {
+      x: clampedX,
+      y: clampedY,
+      width: Math.max(1, clampedWidth),
+      height: Math.max(1, clampedHeight),
+    },
+  };
+};
+
+/**
+ * Get crop frame position in world coordinates
+ */
+export const getCropFrameWorld = (
+  image: CanvasImage
+): { x: number; y: number; width: number; height: number } => ({
+  x: image.x + image.cropFrame.x,
+  y: image.y + image.cropFrame.y,
+  width: image.cropFrame.width,
+  height: image.cropFrame.height,
+});
+
+/**
+ * Check if a point is inside the crop frame (world coordinates)
+ */
+export const containsCropPoint = (
+  image: CanvasImage,
+  worldX: number,
+  worldY: number
+): boolean => {
+  const crop = getCropFrameWorld(image);
+  return (
+    worldX >= crop.x &&
+    worldX <= crop.x + crop.width &&
+    worldY >= crop.y &&
+    worldY <= crop.y + crop.height
+  );
+};
+
+/**
+ * Render image in deselected mode - only the crop frame region is visible
+ */
+export const renderImageDeselected = (
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImage
+): void => {
+  if (image.loaded !== true) return;
+
+  const scaleX = image.image.width / image.width;
+  const scaleY = image.image.height / image.height;
+  const crop = getCropFrameWorld(image);
+
+  ctx.drawImage(
+    image.image,
+    image.cropFrame.x * scaleX,
+    image.cropFrame.y * scaleY,
+    image.cropFrame.width * scaleX,
+    image.cropFrame.height * scaleY,
+    crop.x,
+    crop.y,
+    crop.width,
+    crop.height
+  );
+};
+
+/**
+ * Render image in selected mode - full image faded, crop region at full opacity
+ */
+export const renderImageSelected = (
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImage
+): void => {
+  if (image.loaded !== true) return;
+
+  ctx.save();
+  ctx.globalAlpha = 0.3;
+  ctx.drawImage(image.image, image.x, image.y, image.width, image.height);
+  ctx.restore();
+
+  renderImageDeselected(ctx, image);
+};
+
+export const moveImage = (
+  image: CanvasImage,
+  x: number,
+  y: number
+): CanvasImage => ({
+  ...image,
+  x,
+  y,
+});
+
+export const resizeImage = (
+  image: CanvasImage,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): CanvasImage =>
+  clampCropFrame({
+    ...image,
+    x,
+    y,
+    width: Math.max(1, width),
+    height: Math.max(1, height),
+  });
+
+/**
+ * Update the crop frame on an image (non-destructive)
+ */
+export const updateCropFrame = (
+  image: CanvasImage,
+  cropFrame: CropFrame
+): CanvasImage =>
+  clampCropFrame({
+    ...image,
+    cropFrame,
+  });
+
+/**
+ * Check if a point is inside the image bounds
+ */
+export const containsPoint = (
+  image: CanvasImage,
+  x: number,
+  y: number
+): boolean =>
+  x >= image.x &&
+  x <= image.x + image.width &&
+  y >= image.y &&
+  y <= image.y + image.height;

--- a/src/editor-state.ts
+++ b/src/editor-state.ts
@@ -1,0 +1,99 @@
+/**
+ * Editor state management
+ */
+
+import type { CanvasImage, CropFrame } from "./canvas-image";
+import type { Viewport } from "./viewport";
+import type { HandlePosition } from "./transform-handles";
+
+export type DragMode =
+  | "move-image"
+  | "resize-image"
+  | "resize-crop"
+  | "pan-image-in-crop";
+
+export type EditorState = {
+  readonly viewport: Viewport;
+  readonly images: ReadonlyArray<CanvasImage>;
+  readonly selectedImageId: string | null;
+  readonly activeHandle: HandlePosition | null;
+  readonly dragMode: DragMode | null;
+  readonly dragStart: { readonly x: number; readonly y: number } | null;
+  readonly dragImageStart: { readonly x: number; readonly y: number } | null;
+  readonly dragCropStart: CropFrame | null;
+};
+
+export const createInitialState = (): EditorState => ({
+  viewport: { offsetX: 0, offsetY: 0 },
+  images: [],
+  selectedImageId: null,
+  activeHandle: null,
+  dragMode: null,
+  dragStart: null,
+  dragImageStart: null,
+  dragCropStart: null,
+});
+
+export const addImage = (
+  state: EditorState,
+  image: CanvasImage
+): EditorState => ({
+  ...state,
+  images: [...state.images, image],
+  selectedImageId: image.id,
+});
+
+export const updateImage = (
+  state: EditorState,
+  imageId: string,
+  updater: (img: CanvasImage) => CanvasImage
+): EditorState => ({
+  ...state,
+  images: state.images.map((img) => (img.id === imageId ? updater(img) : img)),
+});
+
+export const selectImage = (
+  state: EditorState,
+  imageId: string | null
+): EditorState => ({
+  ...state,
+  selectedImageId: imageId,
+});
+
+export const getSelectedImage = (state: EditorState): CanvasImage | undefined =>
+  state.images.find((img) => img.id === state.selectedImageId);
+
+export const startDrag = (
+  state: EditorState,
+  dragMode: DragMode,
+  mouseX: number,
+  mouseY: number,
+  imageX: number,
+  imageY: number,
+  handle: HandlePosition | null,
+  cropFrame: CropFrame | null
+): EditorState => ({
+  ...state,
+  dragMode,
+  activeHandle: handle,
+  dragStart: { x: mouseX, y: mouseY },
+  dragImageStart: { x: imageX, y: imageY },
+  dragCropStart: cropFrame,
+});
+
+export const endDrag = (state: EditorState): EditorState => ({
+  ...state,
+  dragMode: null,
+  activeHandle: null,
+  dragStart: null,
+  dragImageStart: null,
+  dragCropStart: null,
+});
+
+export const updateViewport = (
+  state: EditorState,
+  viewport: Viewport
+): EditorState => ({
+  ...state,
+  viewport,
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,334 @@
+/**
+ * UISP - Usable Image Stuff Program
+ * Main entry point
+ */
+
+import {
+  type CanvasImage,
+  loadImage,
+  renderImageDeselected,
+  renderImageSelected,
+  containsPoint,
+  containsCropPoint,
+  moveImage,
+  resizeImage,
+  updateCropFrame,
+} from "./canvas-image";
+import { pan, screenToWorld } from "./viewport";
+import {
+  findHandleAtPoint,
+  getCursorForHandle,
+  renderSelectionUI,
+  calculateResizeBounds,
+  calculateCropFrameBounds,
+} from "./transform-handles";
+import {
+  type EditorState,
+  createInitialState,
+  addImage,
+  updateImage,
+  selectImage,
+  getSelectedImage,
+  startDrag,
+  endDrag,
+  updateViewport,
+} from "./editor-state";
+
+console.log("> Welcome to the Usable Image Stuff Program!");
+
+// State
+let state: EditorState = createInitialState();
+
+// DOM elements
+const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+const ctx = canvas.getContext("2d")!;
+const dropHint = document.getElementById("drop-hint");
+
+// Update drop hint visibility based on whether images are loaded
+const updateDropHintVisibility = (): void => {
+  if (dropHint !== null) {
+    dropHint.classList.toggle("hidden", state.images.length > 0);
+  }
+};
+
+// Resize canvas to fill window
+const resizeCanvas = (): void => {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+};
+
+resizeCanvas();
+window.addEventListener("resize", resizeCanvas);
+
+// Helper to get world coordinates from mouse event
+const getWorldCoords = (event: MouseEvent): { x: number; y: number } =>
+  screenToWorld(state.viewport, event.clientX, event.clientY);
+
+// Find image at point (iterate in reverse to get topmost first)
+const findImageAtPoint = (
+  worldX: number,
+  worldY: number
+): CanvasImage | undefined =>
+  [...state.images].reverse().find((img) => containsPoint(img, worldX, worldY));
+
+// Event handlers
+canvas.addEventListener("mousedown", (event: MouseEvent) => {
+  if (event.button !== 0) return; // Only left click
+
+  const { x: worldX, y: worldY } = getWorldCoords(event);
+  const selectedImage = getSelectedImage(state);
+
+  // Check if clicking on a handle of selected image
+  if (selectedImage !== undefined) {
+    const handleHit = findHandleAtPoint(selectedImage, worldX, worldY);
+    if (handleHit !== null) {
+      const dragMode =
+        handleHit.layer === "crop" ? "resize-crop" : "resize-image";
+      state = startDrag(
+        state,
+        dragMode,
+        worldX,
+        worldY,
+        selectedImage.x,
+        selectedImage.y,
+        handleHit.position,
+        selectedImage.cropFrame
+      );
+      return;
+    }
+
+    // Check if clicking inside the crop frame area (pan image behind crop)
+    if (containsCropPoint(selectedImage, worldX, worldY)) {
+      state = startDrag(
+        state,
+        "pan-image-in-crop",
+        worldX,
+        worldY,
+        selectedImage.x,
+        selectedImage.y,
+        null,
+        selectedImage.cropFrame
+      );
+      return;
+    }
+  }
+
+  // Check if clicking on any image
+  const clickedImage = findImageAtPoint(worldX, worldY);
+
+  if (clickedImage !== undefined) {
+    state = selectImage(state, clickedImage.id);
+    state = startDrag(
+      state,
+      "move-image",
+      worldX,
+      worldY,
+      clickedImage.x,
+      clickedImage.y,
+      null,
+      null
+    );
+  } else {
+    // Clicked on empty space - deselect
+    state = selectImage(state, null);
+  }
+});
+
+canvas.addEventListener("mousemove", (event: MouseEvent) => {
+  const { x: worldX, y: worldY } = getWorldCoords(event);
+  const selectedImage = getSelectedImage(state);
+
+  // Update cursor based on what's under it
+  const updateCursor = (): void => {
+    if (selectedImage !== undefined) {
+      const handleHit = findHandleAtPoint(selectedImage, worldX, worldY);
+      if (handleHit !== null) {
+        canvas.style.cursor = getCursorForHandle(handleHit.position);
+        return;
+      }
+      if (containsCropPoint(selectedImage, worldX, worldY)) {
+        canvas.style.cursor = "grab";
+        return;
+      }
+      if (containsPoint(selectedImage, worldX, worldY)) {
+        canvas.style.cursor = "move";
+        return;
+      }
+    }
+    canvas.style.cursor = "default";
+  };
+
+  if (state.dragMode === null) {
+    updateCursor();
+    return;
+  }
+
+  if (selectedImage === undefined || state.dragStart === null) return;
+
+  // Handle resize-image
+  if (state.dragMode === "resize-image" && state.activeHandle !== null) {
+    const maintainAspectRatio = !event.shiftKey;
+    const resizeBounds = calculateResizeBounds(
+      selectedImage,
+      state.activeHandle,
+      worldX,
+      worldY,
+      maintainAspectRatio
+    );
+
+    state = updateImage(state, selectedImage.id, (img) =>
+      resizeImage(
+        img,
+        resizeBounds.x,
+        resizeBounds.y,
+        resizeBounds.width,
+        resizeBounds.height
+      )
+    );
+    return;
+  }
+
+  // Handle resize-crop
+  if (state.dragMode === "resize-crop" && state.activeHandle !== null) {
+    const cropBounds = calculateCropFrameBounds(
+      selectedImage,
+      state.activeHandle,
+      worldX,
+      worldY
+    );
+
+    state = updateImage(state, selectedImage.id, (img) =>
+      updateCropFrame(img, cropBounds)
+    );
+    return;
+  }
+
+  // Handle pan-image-in-crop (move image behind the crop frame)
+  if (
+    state.dragMode === "pan-image-in-crop" &&
+    state.dragImageStart !== null &&
+    state.dragCropStart !== null
+  ) {
+    const deltaX = worldX - state.dragStart.x;
+    const deltaY = worldY - state.dragStart.y;
+
+    const newImageX = state.dragImageStart.x + deltaX;
+    const newImageY = state.dragImageStart.y + deltaY;
+
+    // Adjust crop frame inversely so it stays at the same world position
+    const newCropFrame = {
+      x: state.dragCropStart.x - deltaX,
+      y: state.dragCropStart.y - deltaY,
+      width: state.dragCropStart.width,
+      height: state.dragCropStart.height,
+    };
+
+    state = updateImage(state, selectedImage.id, (img) =>
+      updateCropFrame(moveImage(img, newImageX, newImageY), newCropFrame)
+    );
+    return;
+  }
+
+  // Handle image drag (move-image)
+  if (
+    state.dragMode === "move-image" &&
+    state.dragImageStart !== null
+  ) {
+    const deltaX = worldX - state.dragStart.x;
+    const deltaY = worldY - state.dragStart.y;
+
+    state = updateImage(state, selectedImage.id, (img) =>
+      moveImage(
+        img,
+        state.dragImageStart!.x + deltaX,
+        state.dragImageStart!.y + deltaY
+      )
+    );
+  }
+});
+
+canvas.addEventListener("mouseup", () => {
+  state = endDrag(state);
+});
+
+// Scroll to pan viewport
+canvas.addEventListener(
+  "wheel",
+  (event: WheelEvent) => {
+    event.preventDefault();
+    state = updateViewport(
+      state,
+      pan(state.viewport, event.deltaX, event.deltaY)
+    );
+  },
+  { passive: false }
+);
+
+// Drag and drop to load images
+canvas.addEventListener("dragover", (event: DragEvent) => {
+  event.preventDefault();
+});
+
+canvas.addEventListener("drop", async (event: DragEvent) => {
+  event.preventDefault();
+
+  const files = Array.from(event.dataTransfer?.files ?? []);
+  const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+
+  const loadPromises = imageFiles.map(async (file) => {
+    const url = URL.createObjectURL(file);
+    const image = await loadImage(url);
+
+    // Center the image in the current viewport
+    const centerX =
+      -state.viewport.offsetX + canvas.width / 2 - image.width / 2;
+    const centerY =
+      -state.viewport.offsetY + canvas.height / 2 - image.height / 2;
+
+    return moveImage(image, centerX, centerY);
+  });
+
+  const loadedImages = await Promise.all(loadPromises);
+
+  loadedImages.forEach((image) => {
+    state = addImage(state, image);
+  });
+
+  updateDropHintVisibility();
+});
+
+// Disable context menu
+canvas.addEventListener("contextmenu", (event: MouseEvent) => {
+  event.preventDefault();
+});
+
+// Render loop
+const render = (): void => {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // Apply viewport transform
+  ctx.save();
+  ctx.translate(state.viewport.offsetX, state.viewport.offsetY);
+
+  // Render all images
+  state.images.forEach((image) => {
+    const isSelected = image.id === state.selectedImageId;
+    if (isSelected) {
+      renderImageSelected(ctx, image);
+    } else {
+      renderImageDeselected(ctx, image);
+    }
+  });
+
+  // Render selection UI for selected image
+  const selectedImage = getSelectedImage(state);
+  if (selectedImage !== undefined) {
+    renderSelectionUI(ctx, selectedImage);
+  }
+
+  ctx.restore();
+
+  requestAnimationFrame(render);
+};
+
+render();

--- a/src/transform-handles.ts
+++ b/src/transform-handles.ts
@@ -1,0 +1,361 @@
+/**
+ * Transform handles for resize/crop operations.
+ * Two layers: outer image handles (resize) and inner crop corner notches.
+ */
+
+import type { CanvasImage } from "./canvas-image";
+import { getCropFrameWorld } from "./canvas-image";
+
+export type HandlePosition = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+
+export type HandleLayer = "image" | "crop";
+
+export type Handle = {
+  readonly position: HandlePosition;
+  readonly x: number;
+  readonly y: number;
+  readonly size: number;
+};
+
+export type HandleHit = {
+  readonly position: HandlePosition;
+  readonly layer: HandleLayer;
+};
+
+const CORNER_HANDLE_SIZE = 10;
+const EDGE_HANDLE_SIZE = 8;
+const CROP_HANDLE_HIT_SIZE = 14;
+const CROP_NOTCH_LENGTH = 16;
+const CROP_NOTCH_LINE_WIDTH = 2.5;
+
+/**
+ * Get all 8 transform handles for the image bounding box
+ */
+export const getImageHandles = (image: CanvasImage): Handle[] => {
+  const { x, y, width, height } = image;
+  const midX = x + width / 2;
+  const midY = y + height / 2;
+  const right = x + width;
+  const bottom = y + height;
+
+  return [
+    { position: "nw", x, y, size: CORNER_HANDLE_SIZE },
+    { position: "n", x: midX, y, size: EDGE_HANDLE_SIZE },
+    { position: "ne", x: right, y, size: CORNER_HANDLE_SIZE },
+    { position: "e", x: right, y: midY, size: EDGE_HANDLE_SIZE },
+    { position: "se", x: right, y: bottom, size: CORNER_HANDLE_SIZE },
+    { position: "s", x: midX, y: bottom, size: EDGE_HANDLE_SIZE },
+    { position: "sw", x, y: bottom, size: CORNER_HANDLE_SIZE },
+    { position: "w", x, y: midY, size: EDGE_HANDLE_SIZE },
+  ];
+};
+
+/**
+ * Get 4 corner handles for the crop frame (world coordinates)
+ */
+export const getCropHandles = (image: CanvasImage): Handle[] => {
+  const crop = getCropFrameWorld(image);
+  const right = crop.x + crop.width;
+  const bottom = crop.y + crop.height;
+
+  return [
+    { position: "nw", x: crop.x, y: crop.y, size: CROP_HANDLE_HIT_SIZE },
+    { position: "ne", x: right, y: crop.y, size: CROP_HANDLE_HIT_SIZE },
+    { position: "se", x: right, y: bottom, size: CROP_HANDLE_HIT_SIZE },
+    { position: "sw", x: crop.x, y: bottom, size: CROP_HANDLE_HIT_SIZE },
+  ];
+};
+
+/**
+ * Check if a point hits a handle
+ */
+export const hitTestHandle = (
+  handle: Handle,
+  pointX: number,
+  pointY: number
+): boolean => {
+  const halfSize = handle.size / 2;
+  return (
+    pointX >= handle.x - halfSize &&
+    pointX <= handle.x + halfSize &&
+    pointY >= handle.y - halfSize &&
+    pointY <= handle.y + halfSize
+  );
+};
+
+/**
+ * Check if the crop frame differs from the full image bounds
+ */
+const hasCropOffset = (image: CanvasImage): boolean =>
+  Math.abs(image.cropFrame.x) > 1 ||
+  Math.abs(image.cropFrame.y) > 1 ||
+  Math.abs(image.cropFrame.width - image.width) > 1 ||
+  Math.abs(image.cropFrame.height - image.height) > 1;
+
+/**
+ * Find which handle (if any) is at the given point.
+ * Checks crop handles first (priority), then image handles.
+ * When crop frame matches full image, skip crop handle hit testing.
+ */
+export const findHandleAtPoint = (
+  image: CanvasImage,
+  pointX: number,
+  pointY: number
+): HandleHit | null => {
+  // Check crop handles first (only if crop frame differs from full image)
+  if (hasCropOffset(image)) {
+    const cropHandles = getCropHandles(image);
+    const cropHit = cropHandles.find((handle) =>
+      hitTestHandle(handle, pointX, pointY)
+    );
+    if (cropHit !== undefined) {
+      return { position: cropHit.position, layer: "crop" };
+    }
+  }
+
+  // Check image handles
+  const imageHandles = getImageHandles(image);
+  const imageHit = imageHandles.find((handle) =>
+    hitTestHandle(handle, pointX, pointY)
+  );
+  if (imageHit !== undefined) {
+    return { position: imageHit.position, layer: "image" };
+  }
+
+  return null;
+};
+
+/**
+ * Get cursor style for a handle position
+ */
+export const getCursorForHandle = (position: HandlePosition): string => {
+  const cursors: Record<HandlePosition, string> = {
+    nw: "nwse-resize",
+    n: "ns-resize",
+    ne: "nesw-resize",
+    e: "ew-resize",
+    se: "nwse-resize",
+    s: "ns-resize",
+    sw: "nesw-resize",
+    w: "ew-resize",
+  };
+  return cursors[position];
+};
+
+/**
+ * Render a single crop corner notch (L-shaped line)
+ */
+const renderCropNotch = (
+  ctx: CanvasRenderingContext2D,
+  cornerX: number,
+  cornerY: number,
+  dirX: number,
+  dirY: number
+): void => {
+  ctx.beginPath();
+  ctx.moveTo(cornerX + dirX * CROP_NOTCH_LENGTH, cornerY);
+  ctx.lineTo(cornerX, cornerY);
+  ctx.lineTo(cornerX, cornerY + dirY * CROP_NOTCH_LENGTH);
+  ctx.stroke();
+};
+
+/**
+ * Render selection UI: image border + handles, crop frame border + notches
+ */
+export const renderSelectionUI = (
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImage
+): void => {
+  const { x, y, width, height } = image;
+  const crop = getCropFrameWorld(image);
+
+  ctx.save();
+
+  // Draw image bounding box border
+  ctx.strokeStyle = "#0099ff";
+  ctx.lineWidth = 2;
+  ctx.setLineDash([]);
+  ctx.strokeRect(x, y, width, height);
+
+  // Draw image handles (filled squares)
+  const imageHandles = getImageHandles(image);
+  ctx.fillStyle = "#ffffff";
+  ctx.strokeStyle = "#0099ff";
+  ctx.lineWidth = 1.5;
+
+  imageHandles.forEach((handle) => {
+    const halfSize = handle.size / 2;
+    ctx.fillRect(
+      handle.x - halfSize,
+      handle.y - halfSize,
+      handle.size,
+      handle.size
+    );
+    ctx.strokeRect(
+      handle.x - halfSize,
+      handle.y - halfSize,
+      handle.size,
+      handle.size
+    );
+  });
+
+  // Draw crop frame border (dashed)
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([4, 4]);
+  ctx.strokeRect(crop.x, crop.y, crop.width, crop.height);
+
+  // Draw crop corner notches (solid L-shapes)
+  ctx.setLineDash([]);
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = CROP_NOTCH_LINE_WIDTH;
+  ctx.lineCap = "square";
+
+  const cropRight = crop.x + crop.width;
+  const cropBottom = crop.y + crop.height;
+
+  renderCropNotch(ctx, crop.x, crop.y, 1, 1);
+  renderCropNotch(ctx, cropRight, crop.y, -1, 1);
+  renderCropNotch(ctx, cropRight, cropBottom, -1, -1);
+  renderCropNotch(ctx, crop.x, cropBottom, 1, -1);
+
+  ctx.restore();
+};
+
+/**
+ * Calculate new bounds when resizing from a specific handle
+ */
+export const calculateResizeBounds = (
+  image: CanvasImage,
+  handle: HandlePosition,
+  mouseX: number,
+  mouseY: number,
+  maintainAspectRatio: boolean
+): { x: number; y: number; width: number; height: number } => {
+  const { x, y, width, height } = image;
+  const aspectRatio = width / height;
+
+  // Start with current bounds
+  let newX = x;
+  let newY = y;
+  let newWidth = width;
+  let newHeight = height;
+
+  // Handle affects different edges
+  const affectsLeft = handle.includes("w");
+  const affectsRight = handle.includes("e");
+  const affectsTop = handle.includes("n");
+  const affectsBottom = handle.includes("s");
+  const isCorner = ["nw", "ne", "sw", "se"].includes(handle);
+
+  if (affectsLeft) {
+    newWidth = x + width - mouseX;
+    newX = mouseX;
+  }
+  if (affectsRight) {
+    newWidth = mouseX - x;
+  }
+  if (affectsTop) {
+    newHeight = y + height - mouseY;
+    newY = mouseY;
+  }
+  if (affectsBottom) {
+    newHeight = mouseY - y;
+  }
+
+  // Maintain aspect ratio for corners (unless shift is held)
+  if (isCorner && maintainAspectRatio) {
+    const newAspect = newWidth / newHeight;
+
+    if (newAspect > aspectRatio) {
+      // Width is too large, adjust it
+      const adjustedWidth = newHeight * aspectRatio;
+      if (affectsLeft) {
+        newX = newX + newWidth - adjustedWidth;
+      }
+      newWidth = adjustedWidth;
+    } else {
+      // Height is too large, adjust it
+      const adjustedHeight = newWidth / aspectRatio;
+      if (affectsTop) {
+        newY = newY + newHeight - adjustedHeight;
+      }
+      newHeight = adjustedHeight;
+    }
+  }
+
+  // Prevent negative dimensions by swapping
+  if (newWidth < 0) {
+    newX = newX + newWidth;
+    newWidth = Math.abs(newWidth);
+  }
+  if (newHeight < 0) {
+    newY = newY + newHeight;
+    newHeight = Math.abs(newHeight);
+  }
+
+  return { x: newX, y: newY, width: newWidth, height: newHeight };
+};
+
+/**
+ * Calculate new crop frame bounds when resizing from a crop corner handle.
+ * Returns crop frame in relative coordinates (relative to image origin).
+ */
+export const calculateCropFrameBounds = (
+  image: CanvasImage,
+  handle: HandlePosition,
+  mouseX: number,
+  mouseY: number
+): { x: number; y: number; width: number; height: number } => {
+  const crop = getCropFrameWorld(image);
+
+  // Clamp mouse to image bounds
+  const clampedX = Math.max(image.x, Math.min(mouseX, image.x + image.width));
+  const clampedY = Math.max(image.y, Math.min(mouseY, image.y + image.height));
+
+  const newCropWorld = (() => {
+    switch (handle) {
+      case "nw":
+        return {
+          x: clampedX,
+          y: clampedY,
+          width: crop.x + crop.width - clampedX,
+          height: crop.y + crop.height - clampedY,
+        };
+      case "ne":
+        return {
+          x: crop.x,
+          y: clampedY,
+          width: clampedX - crop.x,
+          height: crop.y + crop.height - clampedY,
+        };
+      case "sw":
+        return {
+          x: clampedX,
+          y: crop.y,
+          width: crop.x + crop.width - clampedX,
+          height: clampedY - crop.y,
+        };
+      case "se":
+        return {
+          x: crop.x,
+          y: crop.y,
+          width: clampedX - crop.x,
+          height: clampedY - crop.y,
+        };
+      default:
+        return crop;
+    }
+  })();
+
+  // Convert from world to relative coordinates
+  return {
+    x: newCropWorld.x - image.x,
+    y: newCropWorld.y - image.y,
+    width: Math.max(1, newCropWorld.width),
+    height: Math.max(1, newCropWorld.height),
+  };
+};
+
+export const isCornerHandle = (handle: HandlePosition): boolean =>
+  ["nw", "ne", "sw", "se"].includes(handle);


### PR DESCRIPTION
Replace destructive crop with a CropFrame that defines the visible region without modifying pixel data. Selected images show the full image faded with the crop area at full opacity. Deselected images only render the crop frame content. Outer handles resize the image, inner corner notches resize the crop frame, and dragging inside the crop area pans the image behind the frame.